### PR TITLE
MVR-309 Add recipe deletion and restore functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5945,9 +5945,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001642",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001642.tgz",
-      "integrity": "sha512-3XQ0DoRgLijXJErLSl+bLnJ+Et4KqV1PY6JJBGAFlsNsz31zeAIncyeZfLCabHK/jtSh+671RM9YMldxjUPZtA==",
+      "version": "1.0.30001696",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
+      "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/components/recipe/infopanel/InfoPanel.test.tsx
+++ b/src/components/recipe/infopanel/InfoPanel.test.tsx
@@ -20,7 +20,8 @@ const RECIPE: RecipeType = {
     description: 'This is the description for the recipe',
     imageFileName: 'test.jpg',
     servedOn: undefined,
-    cooked: 1
+    cooked: 1,
+    deleted: 0
 };
 
 const CROCKERY_LIST = [

--- a/src/components/recipe/infopanel/pinbutton/PinButton.test.tsx
+++ b/src/components/recipe/infopanel/pinbutton/PinButton.test.tsx
@@ -9,7 +9,8 @@ const recipe: RecipeType = {
     cookingTime: 60,
     description: "A Test Recipe description",
     imageFileName: "image1.jpg",
-    name: "Test Recipe"
+    name: "Test Recipe",
+    deleted: 0
 };
 
 describe('PinButton Component', () => {

--- a/src/pages/admin/AdminHomePage.test.tsx
+++ b/src/pages/admin/AdminHomePage.test.tsx
@@ -3,11 +3,6 @@ import AdminHomePage from "./AdminHomePage";
 import {screen} from "@testing-library/react";
 import React from "react";
 
-/**
- * <li><Link to="/admin/addRecipe">Add a Recipe</Link></li>
- *                     <li><Link to="/admin/manageTags">Manage Tags</Link></li>
- *                     <li><Link to="/admin/manageIdeas">Manage Ideas</Link></li>
- */
 describe('AdminHomePage', () => {
     test('renders "Add a Recipe" link', async () => {
         // Arrange
@@ -30,5 +25,12 @@ describe('AdminHomePage', () => {
 
         // Assert
         expect(screen.getByText('Manage Ideas')).toHaveAttribute('href', '/admin/manageIdeas');
+    });
+    test('renders "Manage Recipes" link', async () => {
+        // Arrange
+        renderWithProviders(<AdminHomePage/>);
+
+        // Assert
+        expect(screen.getByText('Manage Recipes')).toHaveAttribute('href', '/admin/manageRecipes');
     });
 });

--- a/src/pages/admin/AdminHomePage.tsx
+++ b/src/pages/admin/AdminHomePage.tsx
@@ -10,6 +10,7 @@ const AdminHomePage = () => {
                     <li><Link to="/admin/addRecipe">Add a Recipe</Link></li>
                     <li><Link to="/admin/manageTags">Manage Tags</Link></li>
                     <li><Link to="/admin/manageIdeas">Manage Ideas</Link></li>
+                    <li><Link to="/admin/manageRecipes">Manage Recipes</Link></li>
                 </ul>
             </section>
         </>

--- a/src/pages/admin/ManageRecipes.test.tsx
+++ b/src/pages/admin/ManageRecipes.test.tsx
@@ -1,0 +1,95 @@
+import {renderWithProviders} from "../../utils/test-utils";
+import ManageRecipes from "./ManageRecipes";
+import {screen} from "@testing-library/react";
+import React from "react";
+import {
+    useGetRecipesIgnoreDeletedQuery,
+    useMarkRecipeAsDeletedMutation,
+    useRestoreRecipeMutation
+} from "../../store/api";
+import {RecipeType} from "../../types/recipeType";
+
+jest.mock('../../store/api');
+
+const mockGetRecipesIgnoringDeleted = useGetRecipesIgnoreDeletedQuery as jest.MockedFunction<typeof useGetRecipesIgnoreDeletedQuery>;
+const mockMarkRecipeAsDeletedMutation = useMarkRecipeAsDeletedMutation as jest.MockedFunction<typeof useMarkRecipeAsDeletedMutation>;
+const mockRestoreRecipeMutation = useRestoreRecipeMutation as jest.MockedFunction<typeof useRestoreRecipeMutation>;
+
+const RECIPES: RecipeType[] = [
+    {
+        id: 1,
+        name: 'Recipe One',
+        cookingTime: 30,
+        description: 'Recipe One Desc',
+        cooked: 1,
+        imageFileName: 'test1.jpg',
+        deleted: 0
+    },
+    {
+        id: 2,
+        name: 'Recipe Two',
+        cookingTime: 30,
+        description: 'Recipe Two Desc',
+        imageFileName: 'test2.jpg',
+        cooked: 1,
+        deleted: 0
+    }
+];
+
+const prepareGetRecipesIgnoringDeletedMock = (recipes: RecipeType[]) => {
+    mockGetRecipesIgnoringDeleted.mockReturnValue({
+        data: recipes,
+        refetch: jest.fn()
+    });
+    mockMarkRecipeAsDeletedMutation.mockReturnValue([
+        jest.fn(), // Mutation trigger function.
+        {
+            isLoading: false,
+            isError: false,
+            isSuccess: true,
+            data: null,
+            error: null,
+            reset: jest.fn()
+        }
+    ]);
+    mockRestoreRecipeMutation.mockReturnValue([
+        jest.fn(), // Mutation trigger function.
+        {
+            isLoading: false,
+            isError: false,
+            isSuccess: true,
+            data: null,
+            error: null,
+            reset: jest.fn()
+        }
+    ]);
+}
+
+describe('Manage Recipes Page', () => {
+    beforeEach(() => {
+        prepareGetRecipesIgnoringDeletedMock(RECIPES);
+    });
+
+    afterEach(() => {
+        //jest.resetAllMocks();
+    });
+
+    test('renders list of Recipes when Recipes are found', async () => {
+        // Arrange
+        renderWithProviders(<ManageRecipes/>);
+
+        // Assert
+        expect(screen.getByRole('heading', {name: /Recipes/i})).toBeInTheDocument();
+
+        // Check the list
+        const firstRecipe = screen.getByText('Recipe One');
+        expect(firstRecipe).toBeInTheDocument();
+        // expect(firstRecipe).toHaveAttribute('title', 'Idea 1 Name');
+        // expect(firstRecipe).toHaveAttribute('href', 'Idea 1 Url');
+
+        const secondRecipe = screen.getByText('Recipe Two');
+        expect(secondRecipe).toBeInTheDocument();
+        //expect(secondRecipe).toHaveAttribute('title', 'Idea 2 Name');
+        // expect(secondRecipe).toHaveAttribute('href', 'Idea 2 Url');
+    });
+});

--- a/src/pages/admin/ManageRecipes.tsx
+++ b/src/pages/admin/ManageRecipes.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {
+    useGetRecipesIgnoreDeletedQuery,
+    useMarkRecipeAsDeletedMutation,
+    useRestoreRecipeMutation
+} from "../../store/api";
+import _ from "lodash";
+import {RecipeType} from "../../types/recipeType";
+
+const ManageRecipes = () => {
+    const {data: recipes = []} = useGetRecipesIgnoreDeletedQuery({});
+    const hasRecipes = !_.isEmpty(recipes);
+    const [deleteRecipe] = useMarkRecipeAsDeletedMutation();
+    const [restoreRecipe] = useRestoreRecipeMutation();
+
+    return (
+        <section>
+            <h2>Recipes</h2>
+            <ul>
+                {hasRecipes && recipes.map((recipe: RecipeType) => (
+                    <li key={recipe.id}>
+                        <p>{recipe.name}
+                            {recipe.deleted ?
+                                (<button onClick={() => restoreRecipe(recipe)}>Restore</button>) :
+                                (<button onClick={() => deleteRecipe(recipe)}>Delete</button>)
+                            }
+                        </p>
+                    </li>
+                ))}
+                {!hasRecipes && <p>No Recipes to display</p>}
+            </ul>
+        </section>
+    );
+};
+
+export default ManageRecipes;

--- a/src/pages/recipe/Recipe.tsx
+++ b/src/pages/recipe/Recipe.tsx
@@ -115,7 +115,8 @@ const Recipe = () => {
             methodSteps: methodSteps,
             notes: notes,
             imageFileName: imageFileName,
-            tags: selectedTags
+            tags: selectedTags,
+            deleted: 0
         };
 
         if (crockery > 0) {

--- a/src/routes/main-route.js
+++ b/src/routes/main-route.js
@@ -12,6 +12,7 @@ import Convertor from "../pages/convertors/Convertor";
 import Pinned from "../pages/pinned/Pinned";
 import ManageIdeas from "../pages/admin/ManageIdeas";
 import Ideas from "../pages/ideas/Ideas";
+import ManageRecipes from "../pages/admin/ManageRecipes";
 
 export const routes = [
     {
@@ -75,6 +76,10 @@ export const routes = [
                     {
                         path: 'manageIdeas',
                         element: <ManageIdeas/>
+                    },
+                    {
+                        path: 'manageRecipes',
+                        element: <ManageRecipes/>
                     }
                 ]
             }

--- a/src/types/recipeType.ts
+++ b/src/types/recipeType.ts
@@ -13,5 +13,6 @@ export interface RecipeType extends RecipePreviewType {
     basedOn?: string,
     servedOn?: ServedOnType,
     image?: File,
-    tags?: TagType[]
+    tags?: TagType[],
+    deleted: number
 }


### PR DESCRIPTION
Introduced functionality to mark recipes as deleted and restore them within the Admin interface. Added "Manage Recipes" page, updated API endpoints, and adjusted related unit tests and types to support the feature. Updated navigation and routes to include the new page.