### PR TITLE
MVR-206 Implement random image selection for recipes

### DIFF
--- a/src/components/hero/Hero.tsx
+++ b/src/components/hero/Hero.tsx
@@ -3,6 +3,7 @@ import classes from './Hero.module.css';
 import {useNavigate} from "react-router-dom";
 import {useGetRandomDinnerQuery} from "../../store/api";
 import {RecipeType} from "../../types/recipeType";
+import {getRandomImageName} from "../../utils/image/image-utils";
 
 const Hero = () => {
     const getRandomDinnerQuery = useGetRandomDinnerQuery({});
@@ -32,7 +33,7 @@ const Hero = () => {
             {randomRecipe &&
                 <div className={classes['hero-image-container']}>
                     <img className={classes['hero-image']}
-                         src={imgHost + randomRecipe.imageFolderPath + randomRecipe.imageFileNames[0]}
+                         src={imgHost + randomRecipe.imageFolderPath + getRandomImageName(randomRecipe)}
                          alt={randomRecipe.name}/>
                 </div>
             }

--- a/src/components/recipe/infopanel/InfoPanel.tsx
+++ b/src/components/recipe/infopanel/InfoPanel.tsx
@@ -14,6 +14,7 @@ import {CrockeryType} from "../../../types/crockeryType";
 import {RecipeType} from "../../../types/recipeType";
 import RecipeLinkParser from "../recipeLinkParser/RecipeLinkParser";
 import PinButton from "./pinbutton/PinButton";
+import {getRandomImageName} from "../../../utils/image/image-utils";
 
 type Props = {
     recipe: RecipeType,
@@ -113,7 +114,7 @@ const InfoPanel = (props: Props) => {
                 setHeated(recipe.servedOn.heated);
             }
             setImageFileNames(recipe.imageFileNames);
-            setImgSrc(process.env.REACT_APP_STATIC_HOST + recipe.imageFolderPath + recipe.imageFileNames[0]);
+            setImgSrc(process.env.REACT_APP_STATIC_HOST + recipe.imageFolderPath + getRandomImageName(recipe));
         }
     }, [recipe]);
 
@@ -129,7 +130,7 @@ const InfoPanel = (props: Props) => {
 
                 <div className={classes['info-panel']}>
                     {!showFilePicker && !_.isEmpty(imageFileNames) &&
-                        <RecipeImage imageFolderPath={recipe.imageFolderPath} imageFileName={imageFileNames[0]}
+                        <RecipeImage imageFolderPath={recipe.imageFolderPath} imageFileName={getRandomImageName(recipe)}
                                      alt={name} onClick={handleImageClick}/>
                     }
                     {showFilePicker && (

--- a/src/components/recipe/preview/Preview.tsx
+++ b/src/components/recipe/preview/Preview.tsx
@@ -3,6 +3,7 @@ import classes from './Preview.module.css';
 import {useNavigate} from "react-router-dom";
 import {RecipePreviewType} from "../../../types/recipePreviewType";
 import cookedImage from "../../../assets/images/cooked.svg";
+import {getRandomImageName} from "../../../utils/image/image-utils";
 
 type Props = {
     recipe: RecipePreviewType
@@ -10,7 +11,7 @@ type Props = {
 
 const Preview = (props: Props) => {
     const {recipe} = props;
-    const imgSrc = process.env.REACT_APP_STATIC_HOST + recipe.imageFolderPath + recipe.imageFileNames[0];
+    const imgSrc = process.env.REACT_APP_STATIC_HOST + recipe.imageFolderPath + getRandomImageName(recipe)
     const navigate = useNavigate();
     const [isCookedClicked, setIsCookedClicked] = useState(false);
 

--- a/src/utils/image/image-utils.test.tsx
+++ b/src/utils/image/image-utils.test.tsx
@@ -1,0 +1,27 @@
+import {RecipePreviewType} from '../../types/recipePreviewType'
+import {getRandomImageName} from "./image-utils";
+
+describe('getRandomImageName', () => {
+    test('should return the only image for a recipe with just one image', () => {
+        const recipe: RecipePreviewType = {
+            name: 'test',
+            description: 'testing',
+            cooked: 1,
+            imageFolderPath: '/path/to/images',
+            imageFileNames: ['image1.jpg']
+        };
+        expect(getRandomImageName(recipe)).toBe('image1.jpg');
+    });
+
+    test('should return an image from a list of images', () => {
+        const recipe: RecipePreviewType = {
+            name: 'test',
+            description: 'testing',
+            cooked: 1,
+            imageFolderPath: '/path/to/images',
+            imageFileNames: ['image1.jpg', 'image2.jpg', 'image3.jpg']
+        };
+        expect(recipe.imageFileNames).toContain(getRandomImageName(recipe));
+    });
+
+});

--- a/src/utils/image/image-utils.tsx
+++ b/src/utils/image/image-utils.tsx
@@ -1,0 +1,6 @@
+import {RecipePreviewType} from "../../types/recipePreviewType";
+
+export const getRandomImageName = (recipe: RecipePreviewType): string => {
+    const randomIndex = Math.floor(Math.random() * recipe.imageFileNames.length);
+    return recipe.imageFileNames[randomIndex];
+}


### PR DESCRIPTION
Added `getRandomImageName` utility to select a random image from a recipe's image list. Replaced static image selection across components (`Preview`, `InfoPanel`, `Hero`) with this utility to enhance variability in displayed recipe images. Also included unit tests for the new function.